### PR TITLE
fix(diagnostics): mostrar dumps de login rechazado usando checkjc_username

### DIFF
--- a/src/checktime/web/routes/admin.py
+++ b/src/checktime/web/routes/admin.py
@@ -218,12 +218,21 @@ def diagnostics():
     user_manager = UserManager()
     rows = []
     for user in user_manager.list_users():
+        # Captcha dumps are written by the solver using the CheckTime
+        # app username (user.username). Login-failure dumps are written
+        # by the checker using the CheckJC login (user.checkjc_username,
+        # e.g. a DNI), which is what `self.username` resolves to there.
+        # They are NOT the same string, so we must look each category up
+        # under the name its own dumper used or the page shows "—" even
+        # though the file exists on disk.
         safe = _safe_username(user.username)
+        login_name = user.checkjc_username or user.username
+        safe_login = _safe_username(login_name)
         cap_png = os.path.join(_CAPTCHA_DUMP_DIR, f"{safe}.png")
         cap_txt = os.path.join(_CAPTCHA_DUMP_DIR, f"{safe}.txt")
-        log_png = os.path.join(_LOGIN_FAILURE_DIR, f"{safe}.png")
-        log_txt = os.path.join(_LOGIN_FAILURE_DIR, f"{safe}.txt")
-        log_html = os.path.join(_LOGIN_FAILURE_DIR, f"{safe}.html")
+        log_png = os.path.join(_LOGIN_FAILURE_DIR, f"{safe_login}.png")
+        log_txt = os.path.join(_LOGIN_FAILURE_DIR, f"{safe_login}.txt")
+        log_html = os.path.join(_LOGIN_FAILURE_DIR, f"{safe_login}.html")
 
         def _mtime(path):
             try:
@@ -233,6 +242,9 @@ def diagnostics():
 
         rows.append({
             "username": user.username,
+            # Name the login-failure files are actually stored under, so
+            # the template builds the download URL that resolves on disk.
+            "login_username": login_name,
             "user_id": user.id,
             "captcha": {
                 "png": os.path.exists(cap_png),

--- a/src/checktime/web/templates/admin/diagnostics.html
+++ b/src/checktime/web/templates/admin/diagnostics.html
@@ -68,9 +68,9 @@
                                     {% endif %}
                                 </div>
                                 {% if row.login_failure.png %}
-                                    <a href="{{ url_for('admin.diagnostics_file', category='login_failure', username=row.username, ext='png') }}"
+                                    <a href="{{ url_for('admin.diagnostics_file', category='login_failure', username=row.login_username, ext='png') }}"
                                        target="_blank" class="d-inline-block me-2">
-                                        <img src="{{ url_for('admin.diagnostics_file', category='login_failure', username=row.username, ext='png') }}"
+                                        <img src="{{ url_for('admin.diagnostics_file', category='login_failure', username=row.login_username, ext='png') }}"
                                              alt="login failure {{ row.username }}"
                                              style="max-width: 220px; max-height: 110px; border: 1px solid #ddd;">
                                     </a>
@@ -78,14 +78,14 @@
                                 <div class="mt-1 d-flex flex-wrap gap-2">
                                     {% if row.login_failure.html %}
                                         <a class="btn btn-sm btn-outline-primary"
-                                           href="{{ url_for('admin.diagnostics_file', category='login_failure', username=row.username, ext='html') }}"
+                                           href="{{ url_for('admin.diagnostics_file', category='login_failure', username=row.login_username, ext='html') }}"
                                            target="_blank">
                                             <i class="bi bi-code"></i> Ver HTML (source)
                                         </a>
                                     {% endif %}
                                     {% if row.login_failure.txt %}
                                         <a class="btn btn-sm btn-outline-primary"
-                                           href="{{ url_for('admin.diagnostics_file', category='login_failure', username=row.username, ext='txt') }}"
+                                           href="{{ url_for('admin.diagnostics_file', category='login_failure', username=row.login_username, ext='txt') }}"
                                            target="_blank">
                                             <i class="bi bi-file-text"></i> Ver metadatos
                                         </a>


### PR DESCRIPTION
## Problema

Tras un login rechazado por CheckJC, el dump (`html`/`png`/`txt`) se guarda
correctamente en `/var/log/checktime/login_failures/`, pero **la página de
Diagnósticos mostraba "—"** y no permitía ver el HTML ni el screenshot reales
del error.

## Causa raíz

Desajuste de nombre de fichero entre quien escribe el dump y quien lo lee:

| Categoría | Se **guarda** como | La página **buscaba** |
|-----------|--------------------|------------------------|
| Login rechazado | `checkjc_username` (p. ej. el DNI `47779708z`) | `user.username` (nombre de la app, p. ej. `Jose`) ❌ |
| Captcha | `user.username` | `user.username` ✅ |

El checker usa `self.username`, que se construye desde `user.checkjc_username`,
mientras que la página de diagnósticos buscaba todo bajo `user.username`. Por eso
el fichero existía en disco pero nunca se mostraba.

## Cambios

- `src/checktime/web/routes/admin.py`: los dumps de *login rechazado* se buscan
  ahora bajo `checkjc_username`; los de captcha siguen bajo `username`.
- `src/checktime/web/templates/admin/diagnostics.html`: las URLs de descarga del
  login rechazado usan `row.login_username`.

## Cómo verificar

Tras desplegar, abrir Diagnósticos → columna "Login rechazado" del usuario
afectado: deberían aparecer el screenshot y los botones "Ver HTML (source)" y
"Ver metadatos", que muestran exactamente qué devolvió CheckJC en el fallo.

https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc)_