### PR TITLE
fix(checker): habilitar el botón de submit re-disparando input/change

### DIFF
--- a/src/checktime/scheduler/checker.py
+++ b/src/checktime/scheduler/checker.py
@@ -567,6 +567,22 @@ class CheckJCClient:
         for line in self._form_debug:
             logger.info("FORM DEBUG %s -> %s", self.username, line)
 
+        # The submit button (#btn-login) ships `disabled` and is enabled by
+        # the form's own validation once both fields are valid. We observed
+        # it staying disabled even with both fields filled (val_len 9/21):
+        # Stencil attaches that validation listener AFTER its late hydration,
+        # so the input events from our initial keystrokes fired before the
+        # listener existed and the button never re-evaluated. Re-fire
+        # input/change now (listener is attached by submit time) so the
+        # button enables, then record whether it worked.
+        self._dispatch_input_events(user_node)
+        self._dispatch_input_events(pass_node)
+        self._page.wait_for_timeout(500)
+        self._form_debug.append(
+            f"login_button_after_events: {self._describe_node(btn_node)}"
+        )
+        logger.info("FORM DEBUG %s -> %s", self.username, self._form_debug[-1])
+
         # Humanizing mouse warmup before clicking submit: move the pointer
         # toward the button via a couple of intermediate positions instead
         # of teleporting. Cheap and avoids the "perfect-stillness" tell.
@@ -1025,6 +1041,32 @@ class CheckJCClient:
             "type": "mouseReleased", "x": x, "y": y,
             "button": "left", "buttons": 0, "clickCount": 1,
         })
+
+    def _dispatch_input_events(self, node_id):
+        """Re-fire input/change/keyup on a node so a framework that attached
+        its validation listener AFTER our initial keystrokes (late Stencil
+        hydration) re-evaluates the form and enables the submit button.
+
+        Best-effort: swallows its own errors so it never breaks login.
+        """
+        try:
+            obj = self._cdp.send("DOM.resolveNode", {"nodeId": node_id})
+            oid = obj["object"]["objectId"]
+            fn = (
+                "function(){"
+                "this.dispatchEvent(new Event('input',{bubbles:true}));"
+                "this.dispatchEvent(new Event('change',{bubbles:true}));"
+                "this.dispatchEvent(new KeyboardEvent('keyup',{bubbles:true}));"
+                "return true;}"
+            )
+            self._cdp.send("Runtime.callFunctionOn", {
+                "objectId": oid,
+                "functionDeclaration": fn,
+                "returnByValue": True,
+            })
+        except Exception as exc:
+            logger.warning("Could not dispatch input events for %s: %s",
+                           self.username, exc)
 
     def _describe_node(self, node_id):
         """Return a short JSON description of a DOM node (tag, type, id,


### PR DESCRIPTION
## Causa raíz encontrada

El volcado `LOGIN FORM ELEMENTS` lo dejó claro:

```
login_button: {"tag":"BUTTON","type":"submit","id":"btn-login","disabled":true, ...
               <button type="submit" id="btn-login" ... disabled=""> }
```

El **botón de submit está `disabled`**. Los campos tienen valor (`val_len` 9 y 21)
y están dentro de un `<form>`, pero la validación de Stencil mantiene el botón
deshabilitado. Por eso ningún click genera petición: no se puede pulsar un botón
deshabilitado.

Causa probable: Stencil engancha el listener de validación **después** de su
hidratación tardía, así que los eventos `input` de nuestras pulsaciones iniciales
se dispararon antes de que existiera el listener → el form nunca re-evaluó y el
botón se quedó gris.

## Cambio

- **`_dispatch_input_events`**: re-dispara `input`/`change`/`keyup` en usuario y
  password justo antes del submit (con el listener ya enganchado), para que la
  validación se ejecute y habilite el botón.
- Se registra el estado del botón tras los eventos
  (`login_button_after_events`) en el dump y los logs, para confirmar si se
  habilitó.

Sigue siendo **un único submit**.

## Verificación

Tras desplegar, en el dump:
- **`login_button_after_events`** debe mostrar `disabled:false` → el botón se
  habilitó y el click ya envía (veremos el POST de auth en `REQUESTS ATTEMPTED`).
- Si sigue `disabled:true`, el gate no es validación normal (sería anti-bot u
  otra condición) y lo abordamos con ese dato.

https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc)_