### PR TITLE
feat(checker): click real + rebrowser-playwright (evitar detección CDP)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,11 @@ RUN python -m playwright install chromium
 
 ENV PYTHONPATH=/app
 
+# Activa el fix de rebrowser-patches para el leak de Runtime.enable (CDP).
+# "addBinding" es el modo recomendado/por defecto; ponlo a "0" para
+# desactivarlo temporalmente y comparar comportamiento en diagnostico.
+ENV REBROWSER_PATCHES_RUNTIME_FIX_MODE=addBinding
+
 RUN mkdir -p /var/log/checktime && chmod 777 /var/log/checktime
 RUN mkdir -p /app/config && chmod 777 /app/config
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-playwright>=1.47.0
+# Drop-in de Playwright parcheado (rebrowser-patches) para evitar la
+# deteccion de automatizacion por el leak de Runtime.enable (CDP).
+# Mismo import "playwright"; no requiere cambios en el codigo.
+rebrowser-playwright==1.52.0
 python-dotenv==1.0.1
 schedule==1.2.1
 python-telegram-bot==20.8

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@ setup(
         "python-dotenv>=0.19.0",
         "requests>=2.26.0",
         "schedule>=1.1.0",
-        "playwright>=1.47.0",
+        # Drop-in de Playwright parcheado (rebrowser-patches): elimina el
+        # leak de Runtime.enable por CDP que los anti-bot (Cloudflare,
+        # DataDome, y al parecer el sensor de CheckJC/InfoJC) detectan para
+        # identificar automatizacion. Mismo namespace de import "playwright".
+        "rebrowser-playwright==1.52.0",
         "python-telegram-bot>=20.8",
         "flask>=2.3.3",
         "flask-sqlalchemy>=3.1.1",

--- a/src/checktime/scheduler/checker.py
+++ b/src/checktime/scheduler/checker.py
@@ -85,7 +85,12 @@ class CheckJCCaptchaFailed(CheckJCError):
 #      platform leaking through WebGL/navigator.platform — a mismatch that
 #      is itself a bot tell. A standard Linux Chrome is a perfectly common,
 #      non-blacklisted client.
-_CHROME_MAJOR = "147"
+#
+# The value MUST match the Chromium that rebrowser-playwright actually
+# bundles (1.52.0 -> Chromium 136). Declaring a version newer than the real
+# engine is itself a detectable mismatch (feature probing, JS quirks), so we
+# keep UA / Sec-CH-UA / userAgentData in lock-step with the running engine.
+_CHROME_MAJOR = "136"
 _CHROME_UA = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     f"(KHTML, like Gecko) Chrome/{_CHROME_MAJOR}.0.0.0 Safari/537.36"

--- a/src/checktime/scheduler/checker.py
+++ b/src/checktime/scheduler/checker.py
@@ -962,15 +962,29 @@ class CheckJCClient:
         self._cdp.send("DOM.focus", {"nodeId": node_id})
 
     def _human_type_into(self, node_id, text: str):
-        """Focus the node and type its text character-by-character via the
-        Page keyboard so real keydown/keypress/keyup events fire.
+        """Focus the field with a REAL mouse click, then type it
+        character-by-character via the Page keyboard so real
+        keydown/keypress/keyup events fire.
 
-        Necessary because CheckJC's Stencil form validation may listen for
-        input events; `Input.insertText` only mutates value and was flagged
-        by InfoJC's IDS as "manipulation of fields". Per-char random delay
-        also kills the constant-cadence fingerprint.
+        We focus with an actual mouse click (move -> press -> release on the
+        field) instead of CDP `DOM.focus`. The Stencil `<sd-login>` component
+        only starts tracking a field's value after a *genuine* focus/click
+        interaction; with programmatic focus its internal state stayed empty
+        and the submit button (#btn-login) never enabled. A real click is the
+        honest, human way to hand the field focus — no field/control forcing.
+
+        `Input.insertText` is avoided on purpose (InfoJC flagged it as
+        "manipulation of fields"); per-char random delay also kills the
+        constant-cadence fingerprint.
         """
-        self._cdp_focus(node_id)
+        try:
+            self._cdp_click(node_id)
+        except Exception as exc:
+            logger.warning("Real click to focus failed for %s (%s); "
+                           "falling back to DOM.focus", self.username, exc)
+            self._cdp_focus(node_id)
+        # Small settle so the component registers the focus before keys.
+        self._page.wait_for_timeout(random.randint(120, 300))
         delay_min = max(0, get_keystroke_delay_min_ms())
         delay_max = max(delay_min, get_keystroke_delay_max_ms())
         for ch in text:

--- a/src/checktime/scheduler/checker.py
+++ b/src/checktime/scheduler/checker.py
@@ -978,6 +978,13 @@ class CheckJCClient:
         constant-cadence fingerprint.
         """
         try:
+            # Travel the pointer to the field like a human (curved-ish path,
+            # not a teleport) and then click it. Both the movement and the
+            # click go through CDP's input pipeline, so every event carries
+            # isTrusted=true — indistinguishable from a physical mouse at the
+            # JS level, which is the most "real" interaction automation can
+            # produce.
+            self._human_mouse_warmup_to(node_id)
             self._cdp_click(node_id)
         except Exception as exc:
             logger.warning("Real click to focus failed for %s (%s); "


### PR DESCRIPTION
## Contexto

Tres mejoras encadenadas para el bloqueo del login (el botón `#btn-login` se
queda `disabled` y el submit nunca genera petición de auth):

1. **Click real de ratón para enfocar los campos** (en vez de `DOM.focus`): el
   componente Stencil solo registra el valor tras interacción genuina. Eventos
   `isTrusted:true` vía CDP.
2. **Trayectoria de puntero humana** hacia cada campo antes del click.
3. **`rebrowser-playwright==1.52.0`** (drop-in, mismo `import playwright`):
   elimina el leak de **`Runtime.enable`** por CDP que los anti-bot
   (Cloudflare/DataDome/Kasada, y al parecer el sensor de CheckJC) usan para
   detectar automatización y neutralizar la página. Activado con
   `REBROWSER_PATCHES_RUNTIME_FIX_MODE=addBinding`.
   - UA/Sec-CH-UA/userAgentData alineados a **Chrome 136** (el Chromium real que
     trae esa versión) para no contradecir al motor.

## Verificación tras desplegar

En el dump:
- `user_agent:` debe decir **Chrome/136** (confirma que corre esta build).
- `login_button_after_events:` debe pasar a **`disabled:false`** si el parche CDP
  fue el desbloqueo → entonces el click envía y aparece el POST en
  `REQUESTS ATTEMPTED`.

⚠️ Este cambio toca dependencias → la imagen reconstruye Chromium (descarga el de
la 1.52). Confirmar que el build de GHCR termina en verde.

https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc)_