### PR TITLE
fix(stealth): navigator.webdriver = false (valor humano)

### DIFF
--- a/src/checktime/scheduler/checker.py
+++ b/src/checktime/scheduler/checker.py
@@ -118,8 +118,19 @@ _SEC_CH_UA_PLATFORM = '"Linux"'
 # real host, no macOS mismatch.
 _STEALTH_INIT_SCRIPT_TEMPLATE = """
 (() => {
+  // navigator.webdriver: a REAL Chrome returns `false`, not `undefined`.
+  // Returning undefined (old stealth advice) is itself anomalous and a
+  // sensor that checks `webdriver === false` would still flag us — which is
+  // very likely why CheckJC kept the login button disabled. Force the human
+  // value `false`. (--disable-blink-features=AutomationControlled usually
+  // already yields false; this guarantees it and fixes builds where it's
+  // still true.)
   try {
-    Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+    if (navigator.webdriver !== false) {
+      Object.defineProperty(navigator, 'webdriver', {
+        get: () => false, configurable: true,
+      });
+    }
   } catch (_) {}
   try {
     Object.defineProperty(navigator, 'languages', {


### PR DESCRIPTION
## Pista del compañero

Mockeando bien `navigator.webdriver`, el botón de login deja de llegar
deshabilitado. Eso indica que el muro de CheckJC se basa en esa **bandera de
automatización**, no en un sensor irrompible ni en la IP — y por tanto **es
atacable dentro de la arquitectura actual** (Playwright/CheckTime).

## Probable bug nuestro

Nuestro stealth ponía `navigator.webdriver = undefined`, pero un **Chrome real
devuelve `false`**. `undefined` es anómalo; un sensor que compruebe
`webdriver === false` nos seguía marcando como bot → botón disabled.

## Cambio

Forzar `navigator.webdriver = false` (el valor humano), y solo si la flag
`--disable-blink-features=AutomationControlled` no lo hizo ya.

## Verificación
Tras desplegar, en el dump: `login_button_after_events` debería pasar a
`disabled:false` y aparecer el POST de auth en `REQUESTS ATTEMPTED`.

https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc)_