### PR TITLE
fix(diagnostics): cache-bust de imágenes captcha/login por mtime

### DIFF
--- a/src/checktime/web/templates/admin/diagnostics.html
+++ b/src/checktime/web/templates/admin/diagnostics.html
@@ -40,9 +40,9 @@
                                     {% endif %}
                                 </div>
                                 {% if row.captcha.png %}
-                                    <a href="{{ url_for('admin.diagnostics_file', category='captcha', username=row.username, ext='png') }}"
+                                    <a href="{{ url_for('admin.diagnostics_file', category='captcha', username=row.username, ext='png', v=row.captcha.mtime|int) }}"
                                        target="_blank" class="d-inline-block me-2">
-                                        <img src="{{ url_for('admin.diagnostics_file', category='captcha', username=row.username, ext='png') }}"
+                                        <img src="{{ url_for('admin.diagnostics_file', category='captcha', username=row.username, ext='png', v=row.captcha.mtime|int) }}"
                                              alt="captcha {{ row.username }}"
                                              style="max-width: 220px; max-height: 110px; border: 1px solid #ddd;">
                                     </a>
@@ -68,9 +68,9 @@
                                     {% endif %}
                                 </div>
                                 {% if row.login_failure.png %}
-                                    <a href="{{ url_for('admin.diagnostics_file', category='login_failure', username=row.login_username, ext='png') }}"
+                                    <a href="{{ url_for('admin.diagnostics_file', category='login_failure', username=row.login_username, ext='png', v=row.login_failure.mtime|int) }}"
                                        target="_blank" class="d-inline-block me-2">
-                                        <img src="{{ url_for('admin.diagnostics_file', category='login_failure', username=row.login_username, ext='png') }}"
+                                        <img src="{{ url_for('admin.diagnostics_file', category='login_failure', username=row.login_username, ext='png', v=row.login_failure.mtime|int) }}"
                                              alt="login failure {{ row.username }}"
                                              style="max-width: 220px; max-height: 110px; border: 1px solid #ddd;">
                                     </a>


### PR DESCRIPTION
## Problema

Los volcados por usuario (`<user>.png`) se sobreescriben en una URL estable, así que el navegador servía la imagen **cacheada (vieja)** aunque un nuevo fichaje hubiera refrescado el fichero en disco. Resultado: el `.txt` parecía actualizado pero el `.png` no, dificultando el diagnóstico del captcha.

## Fix

Añade `?v=<mtime>` a las URLs de imagen (captcha y login_failure) en Diagnostics, usando el `mtime` que ya está en `row.*.mtime`. Así el navegador siempre baja el volcado actual.

Solo template — sin cambio de lógica.

https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc)_