### PR TITLE
fix(captcha): mensaje de Telegram claro cuando el LLM no lee bien el captcha

### DIFF
--- a/src/checktime/scheduler/checker.py
+++ b/src/checktime/scheduler/checker.py
@@ -935,9 +935,18 @@ class CheckJCClient:
                 return
 
             if "/login" in self._page.url:
-                raise CheckJCSessionLost(
-                    f"Lost session after captcha submit for {self.username} "
-                    f"(redirected back to /login)."
+                # Bounced back to /login right after submitting the keypad
+                # sequence = CheckJC rejected the verification. In practice
+                # this means the answer was WRONG, i.e. the solver (the LLM)
+                # did not read the distorted captcha exactly. Classify it as a
+                # captcha failure (not a generic session loss) so the operator
+                # gets a clear "the captcha couldn't be read" message.
+                raise CheckJCCaptchaFailed(
+                    f"Captcha rejected for {self.username}: CheckJC bounced "
+                    f"back to /login after the keypad sequence, so the answer "
+                    f"was wrong — the automatic reader (LLM) did not read the "
+                    f"captcha digits exactly. A fresh captcha (re-run) usually "
+                    f"succeeds."
                 )
 
             # Still on /verification: wrong digits. Retry with a new captcha.

--- a/src/checktime/scheduler/service.py
+++ b/src/checktime/scheduler/service.py
@@ -87,8 +87,12 @@ def _format_error_for_telegram(check_type, username, exc):
         return f"⏳ {base}: sesión perdida durante el fichaje. Reintentará en el próximo ciclo."
     if isinstance(exc, CheckJCCaptchaFailed):
         return (
-            f"🧩 {base}: no se pudo resolver el captcha de verificación. "
-            f"Ficha manualmente en checkjc.com."
+            f"🧩 {base}: el fichaje NO se realizó porque el captcha de "
+            f"verificación no se leyó correctamente — el lector automático "
+            f"(LLM) no reconoció los dígitos con exactitud y CheckJC rechazó "
+            f"la respuesta. No es un bloqueo ni un problema de credenciales. "
+            f"Vuelve a lanzar el fichaje (con un captcha nuevo suele acertar) "
+            f"o fícha manualmente en checkjc.com."
         )
     if isinstance(exc, CheckJCFormError):
         return f"🧩 {base}: CheckJC cambió el HTML — los selectores ya no casan. Requiere actualización del checker."


### PR DESCRIPTION
## Qué

Cuando el captcha es incorrecto, CheckJC rebota a `/login` tras enviar la secuencia del teclado. Eso se lanzaba como `CheckJCSessionLost` → mensaje "sesión perdida durante el fichaje", que ocultaba la causa real.

## Cambios

- En `_solve_verification`, el rebote a `/login` tras el submit se reclasifica como **`CheckJCCaptchaFailed`** (es un rechazo de la verificación: el lector no leyó el captcha distorsionado con exactitud).
- Mensaje de Telegram reescrito para que sea **claro**:
  > 🧩 ...: el fichaje NO se realizó porque el captcha de verificación no se leyó correctamente — el lector automático (LLM) no reconoció los dígitos con exactitud y CheckJC rechazó la respuesta. No es un bloqueo ni un problema de credenciales. Vuelve a lanzar el fichaje (con un captcha nuevo suele acertar) o fícha manualmente.

Así, cuando Gemini falla un captcha, sabes exactamente qué pasó y que basta con relanzar.

https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc)_