### PR TITLE
feat(captcha): reintento auto opt-in al rechazar el captcha (configurable por env)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,18 @@ CHECKJC_CAPTCHA_CLICK_DELAY_MAX_MS=1200
 CHECKJC_CAPTCHA_SUBMIT_DELAY_MIN_MS=600
 CHECKJC_CAPTCHA_SUBMIT_DELAY_MAX_MS=1500
 
+# Auto-retry when the captcha is REJECTED (the LLM misread the distorted
+# digits and CheckJC bounced back to /login, losing the session). Each retry
+# is a fresh login + fresh captcha, which the reader usually gets right the
+# second time. The captcha is rejected BEFORE reaching the dashboard, so a
+# retry can never double-punch. DEFAULT 0 (notify-and-stop, like before).
+# Set to 1 (or 2, the hard cap) to auto-retry. Only captcha rejections are
+# retried — never credential/lock/IP errors.
+CHECKJC_CAPTCHA_RETRY_ATTEMPTS=0
+# Seconds to wait before each captcha retry — keeps it clear of the
+# rapid-consecutive-login pattern anti-bot systems flag. Default 45.
+CHECKJC_CAPTCHA_RETRY_DELAY_SECONDS=45
+
 # Extra retries when CheckJC serves the "lite" anti-bot HTML variant
 # (body < ~20 KB instead of the normal ~70 KB). DEFAULT 0 — no retry.
 # Zero retries avoids ANY second /login hit (repeated rapid logins are an

--- a/src/checktime/scheduler/service.py
+++ b/src/checktime/scheduler/service.py
@@ -30,6 +30,8 @@ from checktime.scheduler.captcha_solver import (
 )
 from checktime.shared.repository.day_override_repository import DayOverrideRepository
 from checktime.shared.config import (
+    get_captcha_retry_attempts,
+    get_captcha_retry_delay_seconds,
     get_log_level,
     get_post_login_jitter_max_seconds,
     get_post_login_jitter_min_seconds,
@@ -237,44 +239,65 @@ def perform_check_for_user(user, check_type):
             # otherwise (or on LLM failure) fall through to the Telegram
             # human relay. TelegramHumanSolver is unchanged and remains
             # the safety net so today's working flow stays intact.
-            captcha_solver = HybridCaptchaSolver(
-                llm=LLMVisionSolver(),
-                telegram=TelegramHumanSolver(telegram_client=telegram_client),
-            )
-            with CheckJCClient(
-                username=user.checkjc_username,
-                password=user.checkjc_password,
-                subdomain=user.checkjc_subdomain,
-                captcha_solver=captcha_solver,
-                user=user,
-                check_type=check_type,
-            ) as client:
-                client.login()
-                # Human-think pause between login and fichaje. Firing the
-                # check 1-2s after login every single day is a textbook bot
-                # fingerprint for anti-bot / IDS systems. A random 20-90s
-                # pause makes the pattern
-                # indistinguishable from a real user landing on the
-                # dashboard and clicking after a moment.
-                jitter_min = max(0, get_post_login_jitter_min_seconds())
-                jitter_max = max(jitter_min, get_post_login_jitter_max_seconds())
-                if jitter_max > 0:
-                    pause_s = random.uniform(jitter_min, jitter_max)
-                    logger.info(
-                        "Post-login human pause for %s: sleeping %.1fs "
-                        "before fichaje", user.username, pause_s,
+            # Opt-in auto-retry when the captcha is REJECTED (the LLM misread
+            # the distorted digits and CheckJC bounced us back to /login). A
+            # fresh session gets a fresh captcha, which the reader usually
+            # gets right. Only CheckJCCaptchaFailed is retried — never
+            # credential/lock/IP errors — and only AFTER a delay so it never
+            # resembles the rapid-consecutive-login pattern. Default 0 retries
+            # (notify-and-stop) unless CHECKJC_CAPTCHA_RETRY_ATTEMPTS is set.
+            captcha_attempts = get_captcha_retry_attempts() + 1
+            captcha_delay_s = get_captcha_retry_delay_seconds()
+            for _attempt in range(1, captcha_attempts + 1):
+                try:
+                    captcha_solver = HybridCaptchaSolver(
+                        llm=LLMVisionSolver(),
+                        telegram=TelegramHumanSolver(telegram_client=telegram_client),
                     )
-                    time.sleep(pause_s)
-                if check_type == "in":
-                    client.check_in()
-                    icon = "🟢"
-                else:
-                    client.check_out()
-                    icon = "🔴"
-                logger.info(f"{check_type.capitalize()} check completed successfully for user {user.username}.")
-                if hasattr(user, 'telegram_chat_id') and user.telegram_chat_id:
-                    if (hasattr(user, 'telegram_chat_id') and user.telegram_chat_id and getattr(user, 'telegram_notifications_enabled', False)):
-                        telegram_client.send_message(f"{icon} Check {check_type} completed successfully", chat_id=user.telegram_chat_id)
+                    with CheckJCClient(
+                        username=user.checkjc_username,
+                        password=user.checkjc_password,
+                        subdomain=user.checkjc_subdomain,
+                        captcha_solver=captcha_solver,
+                        user=user,
+                        check_type=check_type,
+                    ) as client:
+                        client.login()
+                        # Human-think pause between login and fichaje. Firing
+                        # the check 1-2s after login every single day is a
+                        # textbook bot fingerprint for anti-bot / IDS systems.
+                        # A random 20-90s pause makes the pattern
+                        # indistinguishable from a real user landing on the
+                        # dashboard and clicking after a moment.
+                        jitter_min = max(0, get_post_login_jitter_min_seconds())
+                        jitter_max = max(jitter_min, get_post_login_jitter_max_seconds())
+                        if jitter_max > 0:
+                            pause_s = random.uniform(jitter_min, jitter_max)
+                            logger.info(
+                                "Post-login human pause for %s: sleeping %.1fs "
+                                "before fichaje", user.username, pause_s,
+                            )
+                            time.sleep(pause_s)
+                        if check_type == "in":
+                            client.check_in()
+                            icon = "🟢"
+                        else:
+                            client.check_out()
+                            icon = "🔴"
+                        logger.info(f"{check_type.capitalize()} check completed successfully for user {user.username}.")
+                        if hasattr(user, 'telegram_chat_id') and user.telegram_chat_id:
+                            if (hasattr(user, 'telegram_chat_id') and user.telegram_chat_id and getattr(user, 'telegram_notifications_enabled', False)):
+                                telegram_client.send_message(f"{icon} Check {check_type} completed successfully", chat_id=user.telegram_chat_id)
+                    break  # fichaje OK → salir del bucle de reintento
+                except CheckJCCaptchaFailed:
+                    if _attempt >= captcha_attempts:
+                        raise  # agotados los reintentos → notifica el error claro
+                    logger.warning(
+                        "Captcha rejected for %s (attempt %d/%d): the reader "
+                        "misread it. Retrying with a fresh captcha in %ds.",
+                        user.username, _attempt, captcha_attempts, captcha_delay_s,
+                    )
+                    time.sleep(captcha_delay_s)
         except Exception as e:
             # logger.exception incluye el traceback completo: tipo de excepción,
             # mensaje y línea exacta donde se lanzó. Va al fichero y a stdout.

--- a/src/checktime/shared/config.py
+++ b/src/checktime/shared/config.py
@@ -199,6 +199,27 @@ def get_captcha_submit_delay_max_ms() -> int:
     """Maximum pause before submit. Default 1500ms."""
     return int(get_config('CHECKJC_CAPTCHA_SUBMIT_DELAY_MAX_MS', '1500'))
 
+def get_captcha_retry_attempts() -> int:
+    """Extra full-flow retries when the captcha is REJECTED (the LLM misread
+    the distorted digits and CheckJC bounced us back to /login).
+
+    Each retry is a brand-new session: fresh login + a fresh captcha image,
+    which the LLM usually reads correctly the second time. Since the captcha
+    is rejected BEFORE reaching the dashboard, no fichaje was registered, so
+    retrying can never double-punch.
+
+    Default 0 (opt-in) — current behaviour: notify and stop. Set to 1 (or 2)
+    to auto-retry. Hard-capped at 2 in code: retries are spaced by
+    `get_captcha_retry_delay_seconds()` so they never look like the "rapid
+    consecutive logins" pattern anti-bot systems flag.
+    """
+    return min(2, max(0, int(get_config('CHECKJC_CAPTCHA_RETRY_ATTEMPTS', '0'))))
+
+def get_captcha_retry_delay_seconds() -> int:
+    """Seconds to wait before each captcha retry (see above). Default 45.
+    Keeps the retry well clear of the rapid-login window."""
+    return max(0, int(get_config('CHECKJC_CAPTCHA_RETRY_DELAY_SECONDS', '45')))
+
 # Logging configuration
 def get_log_level() -> str:
     """Get the logging level"""


### PR DESCRIPTION
## Qué resuelve

El reintento de captcha que ya existía (`_solve_verification`, 2 intentos) **solo sirve si CheckJC sigue mostrando `/verification`**. Cuando una respuesta incorrecta te **rebota a `/login`**, la sesión muere y ese reintento no puede hacer nada — que es justo el caso que pierde un fichaje cuando el LLM lee mal el captcha.

## Cambio

Reintento de **flujo completo**: ante `CheckJCCaptchaFailed`, abre una **sesión nueva** (login + captcha frescos, que el lector suele acertar la 2ª vez), hasta N veces. **Configurable por env var, por defecto OFF** (cero cambio de comportamiento):

- `CHECKJC_CAPTCHA_RETRY_ATTEMPTS` — default `0`, tope `2`
- `CHECKJC_CAPTCHA_RETRY_DELAY_SECONDS` — default `45`

Salvaguardas:
- Solo se reintenta `CheckJCCaptchaFailed` — **nunca** credenciales/bloqueo/IP.
- Espera `DELAY` segundos entre intentos → no parece "logins rápidos consecutivos".
- El captcha se rechaza **antes** de llegar al dashboard → un reintento **no puede duplicar** fichaje.

Compila; los avisos F de flake8 (`perform_check` indefinido, imports sin usar) son **preexistentes**, no de esta PR.

https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3j6QnAsoSqzbAev7JBsTc)_